### PR TITLE
fix(nvim): lsp, vue, 使用当前 buffer 路径代替 cwd

### DIFF
--- a/.config/nvim/lua/plugins/extras/lang/vue.lua
+++ b/.config/nvim/lua/plugins/extras/lang/vue.lua
@@ -4,9 +4,10 @@
 return {
   "nvim-lspconfig",
   opts = function(_, opts)
-    local cwd = vim.fn.getcwd()
+    -- get path from current buffer
+    local current_path = vim.fn.expand("%:p:h")
     local util = require("lspconfig.util")
-    local project_root = util.find_node_modules_ancestor(cwd)
+    local project_root = util.find_node_modules_ancestor(current_path)
 
     local vue_path = util.path.join(project_root, "node_modules", "vue")
     local is_vue = vim.fn.isdirectory(vue_path) == 1


### PR DESCRIPTION
非常棒的配置文件，帮我解决了 volar 的配置问题。

可以把 cwd 替换为当前 buffer 的路径，传递给 `find_node_modules_ancestor` 可以向上查找最近的 `node_modules` 目录，我测试了一下，在 monorepo 里可以正常判断是否是 vue 项目。